### PR TITLE
R_install: use R devtools to install "pi0" R-pkg

### DIFF
--- a/lib/galaxy/dependencies/r-packages.txt
+++ b/lib/galaxy/dependencies/r-packages.txt
@@ -2,6 +2,7 @@
 # The run.sh script will install these libraries in the
 # .venv/R/library virtualenv directory.
 
+devtools
 Biobase
 bioDist
 flashClust

--- a/lib/hb/docs/docker/Dockerfile
+++ b/lib/hb/docs/docker/Dockerfile
@@ -16,3 +16,6 @@ RUN apt-get update && apt-get install -y \
    libpq-dev \
    libglu1-mesa-dev
 
+# required by R package "devtools"
+RUN apt-get update && apt-get install -y \
+   libcurl4-openssl-dev

--- a/scripts/R_install_packages.py
+++ b/scripts/R_install_packages.py
@@ -22,12 +22,14 @@ def _install_and_check_r_library(library):
     try:
         r("library('%s')" % library)
     except:
-        install_cmds = \
-            ["install.packages('%s', repos='http://cran.r-project.org', dependencies=TRUE)",
-             "source('http://www.bioconductor.org/biocLite.R'); "
-                "biocLite('%s', suppressUpdates=TRUE, dependencies=TRUE)",
-             "install.packages('%s', repos='http://hyperbrowser.uio.no/eggs_repo/R', "
-                "dependencies=TRUE)"]
+        install_cmds = [
+             "install.packages('%s', repos='http://cran.r-project.org', dependencies=TRUE)"
+             ,"source('http://www.bioconductor.org/biocLite.R'); "
+                "biocLite('%s', suppressUpdates=TRUE, dependencies=TRUE)"
+             ,"install.packages('%s', repos='http://hyperbrowser.uio.no/eggs_repo/R', "
+                "dependencies=TRUE)"
+             ,"devtools::install_version('%s', repos='http://cran.r-project.org')"
+            ]
         exceptions = []
 
         for cmd in install_cmds:


### PR DESCRIPTION
problem:
`run.sh` fails because the R-package package `pi0` was removed from the CRAN repository (now archived). `pi0` is specified in `r-packages.txt` and mainly used in `quick/statistic/McFdr.py`. 
https://cran.r-project.org/web/packages/pi0/index.html

this PR:
Try to install R packages via the R devtools package. This will find `pi0` in the CRAN archive. 

alternative:
Put a version of `pi0` to http://hyperbrowser.uio.no/eggs_repo/R

