### PR TITLE
rm obsolte R pkg install from HB repo

### DIFF
--- a/scripts/R_install_packages.py
+++ b/scripts/R_install_packages.py
@@ -26,8 +26,6 @@ def _install_and_check_r_library(library):
              "install.packages('%s', repos='http://cran.r-project.org', dependencies=TRUE)"
              ,"source('http://www.bioconductor.org/biocLite.R'); "
                 "biocLite('%s', suppressUpdates=TRUE, dependencies=TRUE)"
-             ,"install.packages('%s', repos='http://hyperbrowser.uio.no/eggs_repo/R', "
-                "dependencies=TRUE)"
              ,"devtools::install_version('%s', repos='http://cran.r-project.org')"
             ]
         exceptions = []


### PR DESCRIPTION
@sveinugu Just tested in docker env with clean clone. `devtools::install_version` seems to do the job - no need for the self-hosted R repo for now. 